### PR TITLE
Specify the Ionicons font

### DIFF
--- a/src/MainContent.tsx
+++ b/src/MainContent.tsx
@@ -34,7 +34,7 @@ export class MainContent extends React.Component<IMainContentProps, IMainContent
         await Font.loadAsync({
             Roboto: require("native-base/Fonts/Roboto.ttf"),
             Roboto_medium: require("native-base/Fonts/Roboto_medium.ttf"),
-            ...Ionicons.font
+            Ionicons: require("native-base/Fonts/Ionicons.ttf")
         });
         this.setState({
             isReady: true


### PR DESCRIPTION
It sometimes fails due to not being able to load Ionicons font.
This change may suppress the error.